### PR TITLE
Replace references to outmoded contact methods

### DIFF
--- a/source/eclipsesetup.md
+++ b/source/eclipsesetup.md
@@ -3,8 +3,10 @@ Instructions for setting up Geppetto on Eclipse Neon
 
 Last Update: June 29th 2017
 
-If you have any problems following this documentation please write on
-the [Gitter chat](https://gitter.im/openworm/org.geppetto).
+If you have any problems following this documentation, please drop us a line at
+[info@geppetto.org](mailto:info@geppetto.org) to receive an invitation to our
+Slack channel, where we can assist you. You can also just send us a quick
+question this way.
 
 Another useful page that you might want to check if you any problems
 with the below is the [Tips for developer to configure/deploy Eclipse + Virgo](http://docs.geppetto.org/en/latest/devtips.html).

--- a/source/osxlinuxsetup.md
+++ b/source/osxlinuxsetup.md
@@ -13,7 +13,10 @@ download it from
 `./bin/startup.sh`. The following instructions are if you want to setup
 Geppetto from sources.
 
-Psst: If you get stuck at any point write in the [Gitter chat](https://gitter.im/openworm/org.geppetto), we'll be happy to help you!
+Psst: If you get stuck at any point, you can join our Slack channel and we
+will assist you. Send an email to [info@geppetto.org](mailto:info@geppetto.org)
+for an invite or if you just have a quick question.
+You can also send us screenshots and log files!
 
 Prerequisite software
 ---------------------
@@ -260,10 +263,9 @@ to:
 
 You should now see Geppetto starting up. Good job!
 
-Not quite there yet? Get in touch with us, we are there to help you! You
-can use the [OpenWorm-discuss mailing
-list](https://groups.google.com/forum/#!forum/openworm-discuss) or the
-contact form on the [Geppetto website](http://www.geppetto.org/).
+Not quite there yet? Get in touch with us, we are there to help you!
+Send an email to [info@geppetto.org](mailto:info@geppetto.org) for an
+invitation to our Slack channel or if you just have a quick question.
 
 Using gitall.py
 ---------------

--- a/source/windowssetup.md
+++ b/source/windowssetup.md
@@ -13,10 +13,9 @@ download it from
 `/bin/startup.bat`. The following instructions are if you want to setup
 Geppetto from sources.
 
-Psst: If you get stuck at any point, drop us a line at the
-[OpenWorm-discuss mailing
-list](https://groups.google.com/forum/#!forum/openworm-discuss) or the
-contact form on the [Geppetto website](http://www.geppetto.org/).
+Psst: If you get stuck at any point, you can join our Slack channel and we
+will assist you. Send an email to [info@geppetto.org](mailto:info@geppetto.org)
+for an invite or if you just have a quick question.
 You can also send us screenshots and log files!
 
 Prerequisite software
@@ -174,10 +173,9 @@ to:
 
 You should now see Geppetto starting up. Good job!
 
-Not quite there yet? Get in touch with us, we are there to help you! You
-can use the [OpenWorm-discuss mailing
-list](https://groups.google.com/forum/#!forum/openworm-discuss) or the
-contact form on the [Geppetto website](http://www.geppetto.org/).
+Not quite there yet? Get in touch with us, we are there to help you!
+Send an email to [info@geppetto.org](mailto:info@geppetto.org) for an
+invitation to our Slack channel or if you just have a quick question.
 
 Using gitall.py
 ---------------


### PR DESCRIPTION
Replaces references to the Gitter chat with references to the OpenWorm-discuss mailing list and the contact form on the Geppetto website.